### PR TITLE
fix(canvas): vertically center calendar at all scales

### DIFF
--- a/components/preview/wallpaper-canvas.tsx
+++ b/components/preview/wallpaper-canvas.tsx
@@ -150,7 +150,14 @@ function drawWallpaper(
 
   // Apply normalized offset to calendar block and month title
   const normX = Math.max(-1, Math.min(1, opts.offsetX ?? 0));
-  const normY = Math.max(-1, Math.min(1, opts.offsetY ?? 0));
+  let normY = Math.max(-1, Math.min(1, opts.offsetY ?? 0));
+
+  // FIX: Adjust vertical position based on scale to keep it centered.
+  // At scale 1.0, adjustment is 0. At scale 1.5, adjustment is -0.25.
+  const verticalScaleAdjustment = (scale - 1) * -0.5;
+  normY += verticalScaleAdjustment;
+  normY = Math.max(-1, Math.min(1, normY));
+
   // Allow shifting the grid all the way until its left/right edges touch the canvas edges.
   // Since the grid is centered, the left margin equals the right margin = startX.
   const maxShiftX = startX;


### PR DESCRIPTION
The calendar's vertical position now correctly adjusts for scaling, ensuring it remains centered at any zoom level (e.g., 125%, 150%). This is achieved by applying a dynamic vertical adjustment proportional to the calendar's scale within the drawWallpaper function, preventing it from drifting downwards as it gets larger.