### PR TITLE
fix: prevent path traversal in S3 uploads

### DIFF
--- a/app/api/upload-s3/route.ts
+++ b/app/api/upload-s3/route.ts
@@ -3,6 +3,7 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
+import { sanitizeFilename } from "@/lib/sanitize";
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -59,9 +60,11 @@ export async function POST(request: NextRequest) {
     }
 
     // Generate unique filename with month-year folder structure
+    // FIX: Sanitize the user-provided filename to prevent path traversal
+    const safeFilename = sanitizeFilename(originalFilename);
     const monthYearFolder = `${month}-${year}`;
     const timestamp = Date.now();
-    const s3Key = `wallpapers/${session.user.id}/${monthYearFolder}/${timestamp}-${originalFilename || "wallpaper.png"}`;
+    const s3Key = `wallpapers/${session.user.id}/${monthYearFolder}/${timestamp}-${safeFilename}`;
 
     // Generate presigned POST URL
     // Note: The file field name in the form must match what S3 expects
@@ -110,4 +113,3 @@ export async function POST(request: NextRequest) {
     );
   }
 }
-

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -1,0 +1,55 @@
+/**
+ * Sanitizes a filename to prevent directory traversal and ensure safe S3 keys.
+ * 
+ * Rules:
+ * 1. Removes any sequence of dots (..) to prevent directory traversal
+ * 2. Replaces non-alphanumeric characters (except . _ -) with underscores
+ * 3. Truncates to 100 characters max
+ * 4. Ensures the filename is not empty
+ * 
+ * @param filename - The raw filename from user input
+ * @returns A safe, sanitized filename
+ */
+export function sanitizeFilename(filename: string): string {
+  if (!filename || typeof filename !== "string") {
+    return "wallpaper.png";
+  }
+
+  // 1. Remove leading/trailing whitespace
+  let sanitized = filename.trim();
+
+  // 2. Remove directory traversal sequences (../, ..\, etc.) and any path separators
+  //    We replace them with underscores to break the path structure.
+  sanitized = sanitized.replace(/(\.\.[\/\\])+/g, "_"); // Remove ../ ..\
+  sanitized = sanitized.replace(/[\/\\]/g, "_"); // Remove / and \
+
+  // 3. Keep only alphanumeric, dots, underscores, and hyphens
+  //    This whitelist approach is safer than blacklisting.
+  sanitized = sanitized.replace(/[^a-zA-Z0-9._-]/g, "_");
+
+  // 4. Remove multiple consecutive dots or underscores to keep it clean
+  sanitized = sanitized.replace(/\.{2,}/g, ".");
+  sanitized = sanitized.replace(/_{2,}/g, "_");
+
+  // 5. Ensure it doesn't start with a dot (hidden file)
+  sanitized = sanitized.replace(/^\.+/, "");
+
+  // 6. Truncate to reasonable length (S3 limit is 1024, but 100 is safe for us)
+  if (sanitized.length > 100) {
+    const extIndex = sanitized.lastIndexOf(".");
+    if (extIndex > -1 && extIndex > sanitized.length - 10) {
+      // Keep extension if possible
+      const ext = sanitized.substring(extIndex);
+      sanitized = sanitized.substring(0, 100 - ext.length) + ext;
+    } else {
+      sanitized = sanitized.substring(0, 100);
+    }
+  }
+
+  // 7. Final fallback if sanitization stripped everything
+  if (!sanitized || sanitized === "." || sanitized === "..") {
+    return `wallpaper-${Date.now()}.png`;
+  }
+
+  return sanitized;
+}


### PR DESCRIPTION
## Security Fix: S3 Path Traversal

This PR addresses a **Critical** vulnerability where user-provided filenames were being used directly in S3 keys without sanitization.

### Vulnerability
Previously, a malicious user could supply a filename like `../../malicious.png` to write files outside the intended user directory in the S3 bucket.

### Fix
- Introduced `lib/sanitize.ts` with a strict `sanitizeFilename` function.
- **Whitelist approach:** Only allows alphanumeric characters, dots, underscores, and hyphens.
- **Traversal removal:** Explicitly strips `..` and path separators.
- Applied sanitization in `app/api/upload-s3/route.ts` before generating the S3 key.

Fixes #92